### PR TITLE
[CrT Integration] Replaced Manual register with ZenRegister Annotation

### DIFF
--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/InfuserType.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/InfuserType.java
@@ -14,6 +14,8 @@ import net.minecraft.util.ResourceLocation;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+@ZenRegister
+@ModOnly("mekanism")
 @ZenClass("mods.mekatweaker.InfuserType")
 public class InfuserType {
 	@ZenMethod

--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/PluginCraftTweaker.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/PluginCraftTweaker.java
@@ -1,27 +1,10 @@
 package be.lorexe.mekatweaker.crafttweaker;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import be.lorexe.mekatweaker.MekaTweaker;
-import be.lorexe.mekatweaker.crafttweaker.gas.GasFactory;
-import be.lorexe.mekatweaker.crafttweaker.gas.GasRepresentation;
-import be.lorexe.mekatweaker.crafttweaker.oldgas.OldGasFactory;
-import be.lorexe.mekatweaker.crafttweaker.oldgas.OldGasRepresentation;
 import crafttweaker.CraftTweakerAPI;
-import crafttweaker.IAction;
-import mekanism.api.gas.Gas;
 
 public class PluginCraftTweaker {
 	public static void init() {
-		CraftTweakerAPI.registerClass(GasFactory.class);
-		CraftTweakerAPI.registerClass(GasRepresentation.class);
-		CraftTweakerAPI.registerClass(InfuserType.class);
-
-		CraftTweakerAPI.registerClass(OldGasFactory.class);
-		CraftTweakerAPI.registerClass(OldGasRepresentation.class);
-		
 		CraftTweakerAPI.tweaker.loadScript(false, MekaTweaker.MODID);
 	}
 }

--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/gas/GasFactory.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/gas/GasFactory.java
@@ -1,10 +1,14 @@
 package be.lorexe.mekatweaker.crafttweaker.gas;
 
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.liquid.ILiquidStack;
 import net.minecraftforge.fluids.Fluid;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+@ZenRegister
+@ModOnly("mekanism")
 @ZenClass("mods.mekatweaker.GasFactory")
 public class GasFactory {
 	@ZenMethod

--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/gas/GasRepresentation.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/gas/GasRepresentation.java
@@ -2,6 +2,8 @@ package be.lorexe.mekatweaker.crafttweaker.gas;
 
 import be.lorexe.mekatweaker.MekaTweaker;
 import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import net.minecraft.block.Block;
@@ -20,6 +22,8 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import stanhebben.zenscript.annotations.ZenProperty;
 
+@ZenRegister
+@ModOnly("mekanism")
 @ZenClass("mods.mekatweaker.Gas")
 public class GasRepresentation {
 	@ZenProperty

--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/oldgas/OldGasFactory.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/oldgas/OldGasFactory.java
@@ -1,11 +1,14 @@
 package be.lorexe.mekatweaker.crafttweaker.oldgas;
 
-import be.lorexe.mekatweaker.crafttweaker.gas.GasRepresentation;
 import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.liquid.ILiquidStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+@ZenRegister
+@ModOnly("mekanism")
 @ZenClass("mods.gastweaker.GasFactory")
 @Deprecated
 public class OldGasFactory {

--- a/src/main/java/be/lorexe/mekatweaker/crafttweaker/oldgas/OldGasRepresentation.java
+++ b/src/main/java/be/lorexe/mekatweaker/crafttweaker/oldgas/OldGasRepresentation.java
@@ -1,19 +1,13 @@
 package be.lorexe.mekatweaker.crafttweaker.oldgas;
 
-import be.lorexe.mekatweaker.MekaTweaker;
-import crafttweaker.CraftTweakerAPI;
-import mekanism.api.gas.Gas;
-import mekanism.api.gas.GasRegistry;
-import net.minecraft.block.Block;
-import net.minecraft.block.material.Material;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.BlockFluidClassic;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
 import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+@ZenRegister
+@ModOnly("mekanism")
 @ZenClass("mods.gastweaker.Gas")
 @Deprecated
 public class OldGasRepresentation {


### PR DESCRIPTION
Reason: This allows the registering earlier and thereby also allows for compatibility with other content adding script loaders such as ContentTweaker.

This also allows users to manually do #7 within their own ContentTweaker scripts.
An example for that can be found at <https://gist.github.com/kindlich/b753fc44aabfb8bb7df30656cb3c259c>
An image for the script above in action can be found at <https://puu.sh/EbNN8/0ea45663f4.jpg>